### PR TITLE
Update doc to correct namespace

### DIFF
--- a/onramp/blueprints.rst
+++ b/onramp/blueprints.rst
@@ -849,42 +849,41 @@ To deploy the srsRAN blueprint in simulation mode, run the following:
    $ make srsran-gnb-install
    $ make srsran-uesim-start
 
-Multihop gNBs
-~~~~~~~~~~~~~~~~~~~~~~
+Override Default N3 Subnet
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default OnRamp uses isolated networks for the N3 (e.g.,
-192.168.252.x) and N6 (e.g., 192.168.250.x) interfaces. This prevents
-gNBs on different subnets or located multiple hops away from
-connecting to the UPF on the N3 interface.
+By default, OnRamp manages an isolated subnet (``192.168.252.0/24``)
+for the N3 interface. This prevents attaching gNBs on multiple subnets
+and/or on subnets that are multiple hops away. This section describes
+how to override this setting. It is not technically a self-contained
+blueprint, but rather, a configuration option that can be applied to
+any of the blueprints defined in this section.
 
-In order to support such deployments, OnRamp provides an option to
-configure N3 from the same subnet as ``core.data_iface``. It can be
-enabled by setting setting ``core.upf.multihop_gnb`` to ``true``.
-
-For example, suppose ``core.data_iface`` corresponds to subnet
-10.21.61.0/24 and the gNB is on subnet 10.202.1.0/24. Configure the
-parameters as follows:
+The override requires setting variable ``core.upf.multihop_gnb`` to
+``true``. This causes OnRamp to configure the UPF's N3 interface from
+the same subnet as ``core.data_iface``. For example, suppose
+``core.data_iface`` corresponds to subnet 10.21.61.0/24 and the gNB is
+on subnet 10.202.1.0/24. Configure the parameters as follows:
 
 .. code-block::
 
    data_iface: ens18
    ran_subnet: "10.202.1.0/24"
    upf:
-      access_subnet: "10.21.61.1/24"	# access subnet & gateway
-      core_subnet: "192.168.250.1/24"	# core subnet & gateway
-      multihop_gnb: true
+      access_subnet: "10.21.61.1/24"		# access subnet & gateway
+      core_subnet: "192.168.250.1/24"		# core subnet & gateway
+      multihop_gnb: true			# N3 directly reachable via data_iface
       default_upf:
         ip:
-          access: "10.21.61.12"		#  same subnet as data_iface when multihop_gnb is true
+          access: "10.21.61.12"			# same subnet as data_iface when multihop_gnb=true
           core:   "192.168.250.3"
         ue_ip_pool: "192.168.100.0/24"
 
-To connect multiple gNBs on different subnets, you must modify
-``deps/5gc/roles/core/templates/sdcore-5g-values.yaml`` (if
-``core.upf.mode: af_packet``) or
-``deps/5gc/roles/core/templates/sdcore-5g-sriov-values.yaml`` (if
-``core.upf.mode: dpdk``) to add the necessary routes. For example, if
-a second gNB is on 10.203.1.0/24, then add the route as follows:
+To connect multiple gNBs on different subnets, you must also modify
+the specified values file (e.g.,
+``deps/5gc/roles/core/templates/sdcore-5g-values.yaml``) to add the
+necessary routes. For example, if a second gNB is on 10.203.1.0/24,
+then add the route as follows:
 
 .. code-block::
 

--- a/onramp/devel.rst
+++ b/onramp/devel.rst
@@ -153,7 +153,7 @@ as an example. Consider the following two blocks from the playbook
     kubernetes.core.helm:
       update_repo_cache: true
       name: sd-core
-      release_namespace: aether-5gc
+      release_namespace: omec
       create_namespace: true
       chart_ref: "{{ core.helm.chart_ref }}"
       chart_version: "{{ core.helm.chart_version }}"
@@ -174,7 +174,7 @@ These two tasks correspond to the following three ``helm`` commands:
                             --install \
                             --version $CHART_VERSION \
                             --wait \
-                            --namespace aether-5gc \
+                            --namespace omec \
                             --values $VALUES_FILE \
                             sd-core
 

--- a/onramp/inspect.rst
+++ b/onramp/inspect.rst
@@ -139,7 +139,7 @@ containers running as part of the ``upf-0`` pod:
 
 .. code-block::
 
-   $ kubectl logs -n aether-5gc -p upf-0 bessd
+   $ kubectl logs -n omec -p upf-0 bessd
 
 While ``kubectl`` works just fine for tasks like this, you may also
 want to install `k9s <https://k9scli.io/>`__\ , a terminal-based UI
@@ -149,7 +149,7 @@ namespace that implements SD-Core.
 
 .. code-block::
 
-   $ k9s -n aether-5gc
+   $ k9s -n omec
 
 :numref:`Figure %s <fig-k9s>` shows an example k9s display, where you
 can scroll up and down, and then invoke one of the listed
@@ -161,7 +161,7 @@ the selected pod.
     :width: 700px
     :align: center
 
-    Screenshot of k9s's UI for the ``aether-5gc`` namespace, with the AMF pod
+    Screenshot of k9s's UI for the ``omec`` namespace, with the AMF pod
     currently selected.
 
 
@@ -200,7 +200,7 @@ you learned from ``kubectl`` in place of ``amf-5887bbf6c5-pc9g2``.
 
 .. code-block::
 
-   $ kubectl sniff -n aether-5gc amf-5887bbf6c5-pc9g2 -o - | tshark -r -
+   $ kubectl sniff -n omec amf-5887bbf6c5-pc9g2 -o - | tshark -r -
 
 Of course, you'll also need to restart the RAN emulator to generate
 workload for this tool to capture.

--- a/onramp/network.rst
+++ b/onramp/network.rst
@@ -75,7 +75,7 @@ the container image that implements the UPF, and ``access`` and
 
 .. code-block::
 
-   $ kubectl -n aether-5gc exec -ti upf-0 bessd -- ip addr
+   $ kubectl -n omec exec -ti upf-0 bessd -- ip addr
    1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
        inet 127.0.0.1/8 scope host lo
@@ -121,7 +121,7 @@ the UPF's ``bessd`` container will look something like this:
 
 .. code-block::
 
-   $ kubectl -n aether-5gc exec -ti upf-0 -c bessd -- ip route
+   $ kubectl -n omec exec -ti upf-0 -c bessd -- ip route
    default via 169.254.1.1 dev eth0
    default via 192.168.250.1 dev core metric 110
    10.76.28.0/24 via 192.168.252.1 dev access

--- a/onramp/ref.rst
+++ b/onramp/ref.rst
@@ -106,7 +106,7 @@ the list is not comprehensive.
      - Socket mode for `core.data_iface`; set to `dpdk` to enable DPDK and SR-IOV optimizations.
    * - `core.upf.multihop_gnb`
      - `false`
-     - Routing from `core.data_iface`; set to `true` when external gNB is multiple hops away.
+     - Override default N3 interface; set to `true` when external gNB is multiple hops away.
    * - `gnbsim.data_iface`
      - `ens18`
      - Network interface used by gNBsim; same as `core.data_iface` when co-located on a single server.

--- a/onramp/start.rst
+++ b/onramp/start.rst
@@ -306,12 +306,12 @@ that, type:
 
    $ make aether-5gc-install
 
-``kubectl`` will now show the ``aether-5gc`` namespace running (in addition
+``kubectl`` will now show the ``omec`` namespace running (in addition
 to ``kube-system``), with output similar to the following:
 
 .. code-block::
 
-   $ kubectl get pods -n aether-5gc
+   $ kubectl get pods -n omec
    NAME                         READY   STATUS             RESTARTS      AGE
    amf-5887bbf6c5-pc9g2         1/1     Running            0             6m13s
    ausf-6dbb7655c7-42z7m        1/1     Running            0             6m13s


### PR DESCRIPTION
The onramp documentation refers to aether-5gc namespace, but it seems this has been changed to omec. Update docs to reflect this change